### PR TITLE
Improve Minisat::vec<T> implementation and usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(GNUInstallDirs)
 add_library(libminisat STATIC
     # Impl files
     minisat/core/Solver.cc
+    minisat/core/SolverTypes.cc
     minisat/utils/Options.cc
     minisat/utils/System.cc
     minisat/simp/SimpSolver.cc

--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -45,11 +45,11 @@ public:
     //
     Var     newVar    (bool polarity = true, bool dvar = true); // Add a new variable with parameters specifying variable mode.
 
-    bool    addClause (const vec<Lit>& ps);                     // Add a clause to the solver. 
+    bool    addClause (const vec<Lit>& ps);                     // Add a clause to the solver.
     bool    addEmptyClause();                                   // Add the empty clause, making the solver contradictory.
-    bool    addClause (Lit p);                                  // Add a unit clause to the solver. 
-    bool    addClause (Lit p, Lit q);                           // Add a binary clause to the solver. 
-    bool    addClause (Lit p, Lit q, Lit r);                    // Add a ternary clause to the solver. 
+    bool    addClause (Lit p);                                  // Add a unit clause to the solver.
+    bool    addClause (Lit p, Lit q);                           // Add a binary clause to the solver.
+    bool    addClause (Lit p, Lit q, Lit r);                    // Add a ternary clause to the solver.
     bool    addClause_(      vec<Lit>& ps);                     // Add a clause to the solver without making superflous internal copy. Will
                                                                 // change the passed vector 'ps'.
 
@@ -73,9 +73,9 @@ public:
     void    toDimacs     (const char* file, Lit p);
     void    toDimacs     (const char* file, Lit p, Lit q);
     void    toDimacs     (const char* file, Lit p, Lit q, Lit r);
-    
+
     // Variable mode:
-    // 
+    //
     void    setPolarity    (Var v, bool b); // Declare which polarity the decision heuristic should use for a variable. Requires mode 'polarity_user'.
     void    setDecisionVar (Var v, bool b); // Declare if a variable should be eligible for selection in the decision heuristic.
 
@@ -295,13 +295,13 @@ inline void Solver::varBumpActivity(Var v, double inc) {
 
 inline void Solver::claDecayActivity() { cla_inc *= (1 / clause_decay); }
 inline void Solver::claBumpActivity (Clause& c) {
-        if ( (c.activity() = float(c.activity() + cla_inc)) > 1e20 ) {
-            // Rescale:
-            for (int i = 0; i < learnts.size(); i++) {
-                ca[learnts[i]].activity() = float(ca[learnts[i]].activity() * 1e-20);
-            }
-            cla_inc *= 1e-20; 
+    if ( (c.activity() = float(c.activity() + cla_inc)) > 1e20 ) {
+        // Rescale:
+        for (auto const& learnt : learnts) {
+            ca[learnt].activity() = float(ca[learnt].activity() * 1e-20);
         }
+        cla_inc *= 1e-20;
+    }
 }
 
 inline void Solver::checkGarbage(void){ return checkGarbage(garbage_frac); }
@@ -331,8 +331,8 @@ inline int      Solver::nLearnts      ()      const   { return learnts.size(); }
 inline int      Solver::nVars         ()      const   { return vardata.size(); }
 inline int      Solver::nFreeVars     ()      const   { return (int)dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]); }
 inline void     Solver::setPolarity   (Var v, bool b) { polarity[v] = b; }
-inline void     Solver::setDecisionVar(Var v, bool b) 
-{ 
+inline void     Solver::setDecisionVar(Var v, bool b)
+{
     if      ( b && !decision[v]) dec_vars++;
     else if (!b &&  decision[v]) dec_vars--;
 

--- a/minisat/core/SolverTypes.cc
+++ b/minisat/core/SolverTypes.cc
@@ -1,0 +1,14 @@
+// This file exists only to assert some assumed properties on solver types
+// that were used to optimize Minisat::vec<T> for them.
+// If it fails to compile, it is not neccessarily wrong, just weird.
+
+#include "minisat/core/SolverTypes.h"
+
+#include <type_traits>
+
+namespace Minisat {
+    static_assert(std::is_trivially_destructible<Lit>::value, "Minisat::Lit is expected to be trivially destructible");
+    static_assert(std::is_trivially_destructible<Var>::value, "Minisat::Var is expected to be trivially destructible");
+    static_assert(std::is_trivially_destructible<lbool>::value, "Minisat::lbool is expected to be trivially destructible");
+    static_assert(std::is_trivially_destructible<CRef>::value, "Minisat::CRef is expected to be trivially destructible");
+}

--- a/minisat/mtl/Alg.h
+++ b/minisat/mtl/Alg.h
@@ -51,34 +51,6 @@ static inline bool find(V& ts, const T& t)
     return j < ts.size();
 }
 
-
-//=================================================================================================
-// Copying vectors with support for nested vector types:
-//
-
-// Base case:
-template<class T>
-static inline void copy(const T& from, T& to)
-{
-    to = from;
-}
-
-// Recursive case:
-template<class T>
-static inline void copy(const vec<T>& from, vec<T>& to, bool append = false)
-{
-    if (!append)
-        to.clear();
-    for (int i = 0; i < from.size(); i++){
-        to.push();
-        copy(from[i], to.last());
-    }
-}
-
-template<class T>
-static inline void append(const vec<T>& from, vec<T>& to){ copy(from, to, true); }
-
-//=================================================================================================
 }
 
 #endif

--- a/minisat/mtl/Heap.h
+++ b/minisat/mtl/Heap.h
@@ -45,7 +45,7 @@ class Heap {
     {
         int x  = heap[i];
         int p  = parent(i);
-        
+
         while (i != 0 && lt(x, heap[p])){
             heap[i]          = heap[p];
             indices[heap[p]] = i;
@@ -76,7 +76,7 @@ class Heap {
     Heap(const Comp& c) : lt(c) { }
 
     int  size      ()          const { return heap.size(); }
-    bool empty     ()          const { return heap.size() == 0; }
+    bool empty     ()          const { return heap.empty(); }
     bool inHeap    (int n)     const { return n < indices.size() && indices[n] >= 0; }
     int  operator[](int index) const { assert(index < heap.size()); return heap[index]; }
 
@@ -103,7 +103,7 @@ class Heap {
 
         indices[n] = heap.size();
         heap.push(n);
-        percolateUp(indices[n]); 
+        percolateUp(indices[n]);
     }
 
 
@@ -115,29 +115,31 @@ class Heap {
         indices[x]       = -1;
         heap.pop();
         if (heap.size() > 1) percolateDown(0);
-        return x; 
+        return x;
     }
 
 
     // Rebuild the heap from scratch, using the elements in 'ns':
     void build(vec<int>& ns) {
-        for (int i = 0; i < heap.size(); i++)
-            indices[heap[i]] = -1;
         heap.clear();
+        for (auto& idx : indices) {
+            idx = -1;
+        }
 
         for (int i = 0; i < ns.size(); i++){
             indices[ns[i]] = i;
-            heap.push(ns[i]); }
+            heap.push(ns[i]);
+        }
 
         for (int i = heap.size() / 2 - 1; i >= 0; i--)
             percolateDown(i);
     }
 
-    void clear(bool dealloc = false) 
-    { 
+    void clear(bool dealloc = false)
+    {
         for (int i = 0; i < heap.size(); i++)
             indices[heap[i]] = -1;
-        heap.clear(dealloc); 
+        heap.clear(dealloc);
     }
 };
 

--- a/minisat/mtl/Map.h
+++ b/minisat/mtl/Map.h
@@ -72,7 +72,7 @@ class Map {
     bool    checkCap(int new_size) const { return new_size > cap; }
 
     int32_t index  (const K& k) const { return hash(k) % cap; }
-    void   _insert (const K& k, const D& d) { 
+    void   _insert (const K& k, const D& d) {
         vec<Pair>& ps = table[index(k)];
         ps.push(); ps.last().key = k; ps.last().data = d; }
 
@@ -96,7 +96,7 @@ class Map {
         // printf(" --- rehashing, old-cap=%d, new-cap=%d\n", cap, newsize);
     }
 
-    
+
  public:
 
     Map () : table(NULL), cap(0), size(0) {}
@@ -108,10 +108,11 @@ class Map {
     {
         assert(size != 0);
         const D*         res = NULL;
-        const vec<Pair>& ps  = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
-                res = &ps[i].data;
+        for (auto const& elem : table[index(k)]) {
+            if (equals(elem.key, k)) {
+                res = &elem.data;
+            }
+        }
         assert(res != NULL);
         return *res;
     }
@@ -122,9 +123,11 @@ class Map {
         assert(size != 0);
         D*         res = NULL;
         vec<Pair>& ps  = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
-                res = &ps[i].data;
+        for (auto& elem : table[index(k)]) {
+            if (equals(elem.key, k)) {
+                res = &elem.data;
+            }
+        }
         assert(res != NULL);
         return *res;
     }
@@ -133,20 +136,22 @@ class Map {
     void insert (const K& k, const D& d) { if (checkCap(size+1)) rehash(); _insert(k, d); size++; }
     bool peek   (const K& k, D& d) const {
         if (size == 0) return false;
-        const vec<Pair>& ps = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k)){
-                d = ps[i].data;
-                return true; } 
+        for (auto const& elem : table[index(k)]) {
+            if (equals(elem.key, k)) {
+                d = elem.data;
+                return true;
+            }
+        }
         return false;
     }
 
     bool has   (const K& k) const {
         if (size == 0) return false;
-        const vec<Pair>& ps = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
+        for (auto const& elem : table[index(k)]) {
+            if (equals(elem.key, k)) {
                 return true;
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
These two commits first improve the internals of `Minisat::vec<T>` and then how Minisat itself uses the vector. For more explanations and details see the commit message of the first commit.


## Measurements

I did some informal measurements and the performance impact of these changes is either tiny bit beneficial, or imperceivable. On the set of benchmark in the repository, there were no performance regressions.